### PR TITLE
Add options to configure the manner of mapping DateTimeOffset

### DIFF
--- a/src/EFCore.Jet/Infrastructure/Internal/IJetOptions.cs
+++ b/src/EFCore.Jet/Infrastructure/Internal/IJetOptions.cs
@@ -16,5 +16,13 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
         bool UseOuterSelectSkipEmulationViaDataReader { get; }
         bool EnableMillisecondsSupport { get; }
         bool UseShortTextForSystemString { get; }
+        DateTimeOffsetType DateTimeOffsetType { get; }
+    }
+
+    public enum DateTimeOffsetType
+    {
+        SaveAsString = 0,
+        SaveAsDateTime = 1,
+        SaveAsDateTimeUtc = 2
     }
 }

--- a/src/EFCore.Jet/Infrastructure/Internal/JetOptionsExtension.cs
+++ b/src/EFCore.Jet/Infrastructure/Internal/JetOptionsExtension.cs
@@ -305,6 +305,8 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
                     = Extension._enableMillisecondsSupport.GetHashCode().ToString(CultureInfo.InvariantCulture);
                 debugInfo["Jet:" + nameof(JetDbContextOptionsBuilder.UseShortTextForSystemString)]
                     = Extension._useShortTextForSystemString.GetHashCode().ToString(CultureInfo.InvariantCulture);
+                debugInfo["Jet:" + nameof(JetDbContextOptionsBuilder.UseDateTimeOffsetType)]
+                    = Extension._dateTimeOffsetType.GetHashCode().ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/EFCore.Jet/Infrastructure/Internal/JetOptionsExtension.cs
+++ b/src/EFCore.Jet/Infrastructure/Internal/JetOptionsExtension.cs
@@ -25,6 +25,7 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
         private bool _useOuterSelectSkipEmulationViaDataReader;
         private bool _enableMillisecondsSupport;
         private bool _useShortTextForSystemString;
+        private DateTimeOffsetType _dateTimeOffsetType = DateTimeOffsetType.SaveAsString;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -185,6 +186,23 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
             var clone = (JetOptionsExtension)Clone();
 
             clone._useShortTextForSystemString = enabled;
+
+            return clone;
+        }
+
+        public virtual DateTimeOffsetType DateTimeOffsetType => _dateTimeOffsetType;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual JetOptionsExtension WithUseDateTimeOffsetType(DateTimeOffsetType dateTimeOffsetType = DateTimeOffsetType.SaveAsString)
+        {
+            var clone = (JetOptionsExtension)Clone();
+
+            clone._dateTimeOffsetType = dateTimeOffsetType;
 
             return clone;
         }

--- a/src/EFCore.Jet/Infrastructure/JetDbContextOptionsBuilder.cs
+++ b/src/EFCore.Jet/Infrastructure/JetDbContextOptionsBuilder.cs
@@ -66,6 +66,9 @@ namespace EntityFrameworkCore.Jet.Infrastructure
         public virtual JetDbContextOptionsBuilder UseShortTextForSystemString(bool enabled = true)
             => WithOption(e => e.WithUseShortTextForSystemString(enabled));
 
+        public virtual JetDbContextOptionsBuilder UseDateTimeOffsetType(DateTimeOffsetType dateTimeOffsetType = DateTimeOffsetType.SaveAsString)
+            => WithOption(e => e.WithUseDateTimeOffsetType(dateTimeOffsetType));
+
         /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
         /// </summary>

--- a/src/EFCore.Jet/Internal/JetOptions.cs
+++ b/src/EFCore.Jet/Internal/JetOptions.cs
@@ -31,6 +31,7 @@ namespace EntityFrameworkCore.Jet.Internal
             EnableMillisecondsSupport = jetOptions.EnableMillisecondsSupport;
             ConnectionString = jetOptions.Connection?.ConnectionString ?? jetOptions.ConnectionString!;
             UseShortTextForSystemString = jetOptions.UseShortTextForSystemString;
+            DateTimeOffsetType = jetOptions.DateTimeOffsetType;
         }
 
         /// <summary>
@@ -79,6 +80,13 @@ namespace EntityFrameworkCore.Jet.Internal
                 throw new InvalidOperationException(
                     CoreStrings.SingletonOptionChanged(
                         nameof(JetOptionsExtension.UseShortTextForSystemString),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
+            }
+            if (DateTimeOffsetType != jetOptions.DateTimeOffsetType)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.SingletonOptionChanged(
+                        nameof(JetOptionsExtension.DateTimeOffsetType),
                         nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
             }
         }
@@ -159,5 +167,7 @@ namespace EntityFrameworkCore.Jet.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual string? ConnectionString { get; private set; }
+
+        public DateTimeOffsetType DateTimeOffsetType { get; private set; }
     }
 }

--- a/src/EFCore.Jet/Storage/Internal/JetDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDateTimeOffsetTypeMapping.cs
@@ -37,8 +37,21 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             // OLE DB can't handle the DateTimeOffset type.
             if (parameter.Value is DateTimeOffset dateTimeOffset)
             {
-                parameter.Value = dateTimeOffset.ToString("O");
-                parameter.DbType = System.Data.DbType.String;
+                if (_options.DateTimeOffsetType == DateTimeOffsetType.SaveAsString)
+                {
+                    parameter.Value = dateTimeOffset.ToString("O");
+                    parameter.DbType = System.Data.DbType.String;
+                }
+                else if (_options.DateTimeOffsetType == DateTimeOffsetType.SaveAsDateTime)
+                {
+                    parameter.Value = dateTimeOffset.DateTime;
+                    parameter.DbType = System.Data.DbType.DateTime;
+                }
+                else if (_options.DateTimeOffsetType == DateTimeOffsetType.SaveAsDateTimeUtc)
+                {
+                    parameter.Value = dateTimeOffset.UtcDateTime;
+                    parameter.DbType = System.Data.DbType.DateTime;
+                }
             }
 
             base.ConfigureParameter(parameter);

--- a/src/EFCore.Jet/Storage/Internal/JetTypeMappingSource.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetTypeMappingSource.cs
@@ -92,7 +92,7 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 
             _datetime = new JetDateTimeTypeMapping("datetime", options, dbType: DbType.DateTime);
             _dateasdatetime = new JetDateTimeTypeMapping("date", options, dbType: DbType.Date);
-            _datetimeoffset = new JetDateTimeOffsetTypeMapping("varchar(50)", options);
+            _datetimeoffset = new JetDateTimeOffsetTypeMapping(options.DateTimeOffsetType == DateTimeOffsetType.SaveAsString ? "varchar(50)" : "datetime", options);
             _dateonly = new JetDateOnlyTypeMapping("date", options, dbType: DbType.Date);
             _timeonly = new JetTimeOnlyTypeMapping("time", options);
             _timespan = new JetTimeSpanTypeMapping("datetime", options);


### PR DESCRIPTION
The default mapping for DateTimeOffset has changed to being mapped to a string

This has the benefit of being able to round-trip the value without any loss of value. On the downside, it does not allow any calculations or standard date/time queries on the components of the value. It is also not backwards compatible to previous versions

This PR introduces a new option when configuring the `DbContext`, `UseDateTimeOffsetType`.

This will allow you to configure the usage as either a string, datetime (local time/no adjustments made), datetime (converted to UTC) depending on your preferences