### PR TITLE
Fix CI for releases.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -338,7 +338,7 @@ jobs:
           path: ${{ env.commitGreenTestsFile }}
   NuGet:
     needs: BuildAndTest
-    if: always() && (needs.BuildAndTest.result == 'success' || needs.BuildAndTest.result == 'skipped') && github.repository == 'CirrusRedOrg/EntityFrameworkCore.Jet'
+    if: always() && (needs.BuildAndTest.result == 'success' || needs.BuildAndTest.result == 'skipped') && (github.event_name == 'push' || github.event_name == 'release') && github.repository == 'CirrusRedOrg/EntityFrameworkCore.Jet'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/Version.props
+++ b/Version.props
@@ -2,12 +2,16 @@
 	<PropertyGroup Label="Version settings">
 		<!--
             Use the following values for the different release types:
-                - "alpha"
-                - "beta"
-                - "rc"
-                - "rtm"
-                - "servicing"
+          - "alpha"     - EF Core release independent, code quality unstable,         major changes
+          - "beta"      - EF Core release independent, code quality stable,           can introduce breaking changes
+          - "silver"    - EF Core release independent, code quality stable,           only minor changes are expected
 
+          - "preview"   - EF Core release targeted,    code quality stable,           can introduce breaking changes
+          - "rc"        - EF Core release targeted,    code quality production ready, only minor changes are expected
+
+          - "rtm"       - EF Core release independent, code quality production ready, major release
+          - "servicing" - EF Core release independent, code quality production ready, mainly bugfixes
+          
             Bump-up to the next iteration immediately after a release, so that subsequent daily builds are named
             correctly.
         -->
@@ -24,34 +28,37 @@
 	</PropertyGroup>
 
 	<!--
-        If no version or version suffix or official version has been explicitly set, we generate a version suffix in the following format:
+    If no official version has been explicitly set (or no version or version suffix), we generate a version suffix in the following formats:
             alpha.1.ci.20201004T181121Z+sha.0a1b2c3
+            alpha.1.ci.20201004T181121Z.debug+sha.0a1b2c3
     -->
 	<PropertyGroup>
 		<UseVersionOverride Condition="'$(Version)' != ''">true</UseVersionOverride>
 		<UseVersionSuffixOverride Condition="'$(VersionSuffix)' != ''">true</UseVersionSuffixOverride>
+		<FinalOfficialVersion>$(OfficialVersion)</FinalOfficialVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Label="Version Suffix Handling" Condition="'$(UseVersionOverride)' != 'true' And '$(UseVersionSuffixOverride)' != 'true' And ('$(OfficialVersion)' == '' Or ($(OfficialVersion.Contains('-')) And '$(OfficialVersion)' != '-debug'))">
-		<VersionSuffix>$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</VersionSuffix>
-		<VersionSuffix Condition="'$(ContinuousIntegrationTimestamp)' != ''">$(VersionSuffix).ci.$(ContinuousIntegrationTimestamp)</VersionSuffix>
+	<PropertyGroup Label="Version Suffix Handling" Condition="'$(UseVersionOverride)' != 'true' And '$(UseVersionSuffixOverride)' != 'true'">
+		<VersionSuffix Condition="'$(OfficialVersion)' == '' Or $(OfficialVersion.Contains('-'))">$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</VersionSuffix>
+		<VersionSuffix Condition="'$(OfficialVersion)' == '' And '$(ContinuousIntegrationTimestamp)' != ''">$(VersionSuffix).ci.$(ContinuousIntegrationTimestamp)</VersionSuffix>
 		<VersionSuffix Condition="'$(Configuration)' == 'Debug'">$(VersionSuffix).debug</VersionSuffix>
 		<VersionSuffix Condition="'$(BuildSha)' != ''">$(VersionSuffix)+sha.$(BuildSha)</VersionSuffix>
-	</PropertyGroup>
+		<VersionSuffix>$(VersionSuffix.TrimStart(`.`))</VersionSuffix>
 
-	<PropertyGroup Condition="'$(VersionSuffix)' == ''">
-		<VersionSuffix Condition="'$(Configuration)' == 'Debug'">debug</VersionSuffix>
+		<FinalOfficialVersion Condition="'$(Configuration)' == 'Debug' And $(FinalOfficialVersion.Contains('-'))">$(FinalOfficialVersion).debug</FinalOfficialVersion>
+		<FinalOfficialVersion Condition="'$(Configuration)' == 'Debug' And !$(FinalOfficialVersion.Contains('-'))">$(FinalOfficialVersion)-debug</FinalOfficialVersion>
 	</PropertyGroup>
 
 	<Target Name="EnsureVersionParameters" BeforeTargets="CoreBuild" Condition="'$(UseVersionOverride)' != 'true' And '$(UseVersionSuffixOverride)' != 'true'">
+		<Message Condition="'$(OfficialVersion)' != ''" Importance="high" Text="OfficialVersion: $(OfficialVersion)" />
+		<Message Condition="'$(OfficialVersion)' != ''" Importance="high" Text="FinalOfficialVersion: $(FinalOfficialVersion)" />
+		<Message Condition="'$(OfficialVersion)' != ''" Importance="high" Text="VersionPrefix: $(VersionPrefix)" />
+		<Message Condition="'$(OfficialVersion)' != ''" Importance="high" Text="VersionSuffix: $(VersionSuffix)" />
+		<Message Condition="'$(OfficialVersion)' != ''" Importance="high" Text="Version: $(Version)" />
+
 		<Error Condition="'$(VersionPrefix)' == ''" Text="The 'VersionPrefix' property needs to be set."/>
 		<Error Condition="'$(PreReleaseVersionLabel)' == ''" Text="The 'PreReleaseVersionLabel' property needs to be set."/>
 		<Error Condition="'$(PreReleaseVersionIteration)' == ''" Text="The 'PreReleaseVersionIteration' property needs to be set."/>
-		<Error Condition="'$(OfficialVersion)' != '' And '$(OfficialVersion)' != '$(VersionPrefix)' And '$(OfficialVersion)' != '$(VersionPrefix)-$(VersionSuffix)'" Text="The 'OfficialVersion' property needs to be identical to the 'VersionPrefix' property or to a combination of the 'VersionPrefix' and the 'VersionSuffix' properties."/>
-		<!--
-        <Message Importance="high" Text="VersionPrefix: $(VersionPrefix)" />
-        <Message Importance="high" Text="VersionSuffix: $(VersionSuffix)" />
-        <Message Importance="high" Text="Version: $(Version)" />
-        -->
+		<Error Condition="'$(OfficialVersion)' != '' And '$(FinalOfficialVersion)' != '$(VersionPrefix)' And '$(FinalOfficialVersion)' != '$(VersionPrefix)-$(VersionSuffix)'" Text="The 'OfficialVersion' property needs to be identical to the 'VersionPrefix' property or to a combination of the 'VersionPrefix' and the 'VersionSuffix' properties." />
 	</Target>
 </Project>


### PR DESCRIPTION
All the necessary fixes for the CI release process can be found in:

- https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/commit/9d67597850a1b5c3a44c9515e3b1c625c896f951
- https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/commit/f5ea712f52d9b24c166d7e82c39f3f15332f9c24
- https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/commit/a29b002844a040be8cbac143ce81db5eb1a5eaa4

This PR adds the pieces that are still currently missing from _our_ CI workflow here.