### PR TITLE
Some tests need the GUID to be formatted with braces so that it matches what is returned from Jet

### DIFF
--- a/test/EFCore.Jet.FunctionalTests/Query/GearsOfWarQueryJetTest.cs
+++ b/test/EFCore.Jet.FunctionalTests/Query/GearsOfWarQueryJetTest.cs
@@ -8,6 +8,7 @@ using Xunit.Abstractions;
 using EntityFrameworkCore.Jet.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using System.Linq;
+using Xunit;
 
 namespace EntityFrameworkCore.Jet.FunctionalTests.Query
 {
@@ -9034,11 +9035,20 @@ WHERE `m`.`Rating` IS NULL
 
         public override async Task ToString_guid_property_projection(bool async)
         {
-            await base.ToString_guid_property_projection(async);
+            await AssertQuery(
+                async,
+                ss => ss.Set<CogTag>().Select(
+                    ct => new { A = ct.GearNickName, B = ct.Id.ToString("B") }),
+                elementSorter: e => e.B,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.A, a.A);
+                    Assert.Equal(e.B.ToLower(), a.B.ToLower());
+                });
 
             AssertSql(
-    """
-SELECT `t`.`GearNickName` AS `A`, CONVERT(varchar(36), `t`.`Id`) AS `B`
+                """
+SELECT `t`.`GearNickName`, `t`.`Id`
 FROM `Tags` AS `t`
 """);
         }

--- a/test/EFCore.Jet.FunctionalTests/Query/TPCGearsOfWarQueryJetTest.cs
+++ b/test/EFCore.Jet.FunctionalTests/Query/TPCGearsOfWarQueryJetTest.cs
@@ -12128,12 +12128,21 @@ WHERE `m`.`CodeName` = 'Operation Foobar'
 
     public override async Task ToString_guid_property_projection(bool async)
     {
-        await base.ToString_guid_property_projection(async);
+        await AssertQuery(
+            async,
+            ss => ss.Set<CogTag>().Select(
+                ct => new { A = ct.GearNickName, B = ct.Id.ToString("B") }),
+            elementSorter: e => e.B,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.A, a.A);
+                Assert.Equal(e.B.ToLower(), a.B.ToLower());
+            });
 
         AssertSql(
-"""
-SELECT [t].[GearNickName] AS [A], CONVERT(varchar(36), [t].[Id]) AS [B]
-FROM [Tags] AS [t]
+            """
+SELECT `t`.`GearNickName`, `t`.`Id`
+FROM `Tags` AS `t`
 """);
     }
 

--- a/test/EFCore.Jet.FunctionalTests/Query/TPTGearsOfWarQueryJetTest.cs
+++ b/test/EFCore.Jet.FunctionalTests/Query/TPTGearsOfWarQueryJetTest.cs
@@ -9833,14 +9833,21 @@ WHERE `m`.`CodeName` = 'Operation Foobar'
 
     public override async Task ToString_guid_property_projection(bool async)
     {
-        await base.ToString_guid_property_projection(async);
+        await AssertQuery(
+            async,
+            ss => ss.Set<CogTag>().Select(
+                ct => new { A = ct.GearNickName, B = ct.Id.ToString("B") }),
+            elementSorter: e => e.B,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.A, a.A);
+                Assert.Equal(e.B.ToLower(), a.B.ToLower());
+            });
 
         AssertSql(
-"""
-SELECT `f`.`Id`, `f`.`CapitalName`, `f`.`Name`, `f`.`ServerAddress`, `l`.`CommanderName`, `l`.`Eradicated`, IIF(`l`.`Id` IS NOT NULL, 'LocustHorde', NULL) AS `Discriminator`, `c`.`Name`, `c`.`Location`, `c`.`Nation`
-FROM (`Factions` AS `f`
-LEFT JOIN `LocustHordes` AS `l` ON `f`.`Id` = `l`.`Id`)
-LEFT JOIN `Cities` AS `c` ON `f`.`CapitalName` = `c`.`Name`
+            """
+SELECT `t`.`GearNickName`, `t`.`Id`
+FROM `Tags` AS `t`
 """);
     }
 


### PR DESCRIPTION
Overwrite the base test call. We need to explicitly format the guid when converted to string. Jet differs from other databases in that it defaults to using braces versus having none