### PR TITLE
Fix supported EF Core version range

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<EFCoreVersion>[8.0.2, 9.0.0)</EFCoreVersion>
+		<EFCoreVersion>[8.0.2,8.0.999]</EFCoreVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
We previously used ranges like `[8.0.2,9.0.0)` (from `8.0.0` inclusive, to `9.0.0` exclusive).

Unfortunately, this includes all `9.0.0` prereleases like `9.0.0-preview.1` etc.
The range `[8.0.2,9.0.0-0)` doesn't work either for us, because when publishing to nuget.org, `9.0.0-0` is recognized as a prerelease version, which is prohibited (at least by default) for production release packages (at least we got errors back when we tried to publish the Pomelo `8.0.0` release).

Because EF Core providers are typically only compatible with a specific version train of EF Core, we now use `[8.0.2,8.0.999]`. We could have used `[8.0.2,8.999.0]` instead, but better save than sorry.