### PR TITLE
Add option to ignore msys tables when scaffolding

### DIFF
--- a/src/EFCore.Jet.Data/AdoxSchema.cs
+++ b/src/EFCore.Jet.Data/AdoxSchema.cs
@@ -13,6 +13,7 @@ namespace EntityFrameworkCore.Jet.Data
         private readonly dynamic _connection;
         private readonly dynamic _catalog;
 
+        private bool _ignoreMsys;
         public AdoxSchema(JetConnection connection, bool naturalOnly, bool readOnly)
             : this(connection, readOnly)
         {
@@ -22,7 +23,7 @@ namespace EntityFrameworkCore.Jet.Data
         public AdoxSchema(JetConnection connection, bool readOnly)
         {
             _connection = new ComObject("ADODB.Connection");
-
+            _ignoreMsys = connection.IgnoreMsys;
             try
             {
                 var connectionString = GetOleDbConnectionString(connection.ActiveConnectionString);
@@ -104,6 +105,11 @@ namespace EntityFrameworkCore.Jet.Data
                 using var properties = table.properties;
 
                 var tableName = (string)table.Name;
+
+                if (tableName.StartsWith("MSys", StringComparison.OrdinalIgnoreCase) && _ignoreMsys)
+                {
+                    continue;
+                }
 
                 // Depending on the provider (ODBC or OLE DB) used, the Tables collection might contain VIEWs
                 // that take parameters, which makes them procedures.
@@ -202,6 +208,12 @@ namespace EntityFrameworkCore.Jet.Data
                 using var table = tables[i];
                 var tableName = (string)table.Name;
 
+                if (tableName.StartsWith("MSys", StringComparison.OrdinalIgnoreCase) && _ignoreMsys)
+                {
+                    continue;
+                }
+
+                System.Console.WriteLine(tableName);
                 using var columns = table.Columns;
                 var columnCount = columns.Count;
 
@@ -282,6 +294,11 @@ namespace EntityFrameworkCore.Jet.Data
                 using var table = tables[i];
                 var tableName = (string)table.Name;
 
+                if (tableName.StartsWith("MSys", StringComparison.OrdinalIgnoreCase) && _ignoreMsys)
+                {
+                    continue;
+                }
+
                 using var indexes = table.Indexes;
                 var indexCount = (int)indexes.Count;
 
@@ -337,6 +354,11 @@ namespace EntityFrameworkCore.Jet.Data
                 using var table = tables[i];
                 var tableName = (string)table.Name;
 
+                if (tableName.StartsWith("MSys", StringComparison.OrdinalIgnoreCase) && _ignoreMsys)
+                {
+                    continue;
+                }
+
                 using var indexes = table.Indexes;
                 var indexCount = (int)indexes.Count;
 
@@ -383,6 +405,11 @@ namespace EntityFrameworkCore.Jet.Data
             {
                 using var table = tables[i];
                 var referencingTableName = (string)table.Name;
+
+                if (table.Name.StartsWith("MSys", StringComparison.OrdinalIgnoreCase) && _ignoreMsys)
+                {
+                    continue;
+                }
 
                 using var keys = table.Keys;
                 var keyCount = (int)keys.Count;
@@ -445,6 +472,11 @@ namespace EntityFrameworkCore.Jet.Data
             for (var i = 0; i < tableCount; i++)
             {
                 using var table = tables[i];
+
+                if (table.Name.StartsWith("MSys", StringComparison.OrdinalIgnoreCase) && _ignoreMsys)
+                {
+                    continue;
+                }
 
                 using var keys = table.Keys;
                 var keyCount = (int)keys.Count;

--- a/src/EFCore.Jet.Data/AdoxSchema.cs
+++ b/src/EFCore.Jet.Data/AdoxSchema.cs
@@ -213,7 +213,6 @@ namespace EntityFrameworkCore.Jet.Data
                     continue;
                 }
 
-                System.Console.WriteLine(tableName);
                 using var columns = table.Columns;
                 var columnCount = columns.Count;
 

--- a/src/EFCore.Jet.Data/JetConnection.cs
+++ b/src/EFCore.Jet.Data/JetConnection.cs
@@ -28,7 +28,7 @@ namespace EntityFrameworkCore.Jet.Data
         internal string? FileNameOrConnectionString => ConnectionString;
 
         public const string DefaultDualTableName = "#Dual";
-
+        private bool _ignoreMSys;
         /// <summary>
         /// Initializes a new instance of the <see cref="JetConnection"/> class.
         /// </summary>
@@ -80,6 +80,8 @@ namespace EntityFrameworkCore.Jet.Data
         ///   <c>true</c> if this instance is empty; otherwise, <c>false</c>.
         /// </value>
         public bool IsEmpty { get; set; }
+
+        public bool IgnoreMsys => _ignoreMSys;
 
         /// <summary>
         /// Gets the <see cref="T:System.Data.Common.DbProviderFactory" /> for this <see cref="T:System.Data.Common.DbConnection" />.
@@ -357,6 +359,12 @@ namespace EntityFrameworkCore.Jet.Data
             // In that case, we need to retrieving the data access provider type's most recent ACE/Jet provider.
             var connectionStringBuilder = DataAccessProviderFactory.CreateConnectionStringBuilder();
             connectionStringBuilder.ConnectionString = connectionString;
+
+            if (connectionStringBuilder.Remove("IgnoreMsys"))
+            {
+                _ignoreMSys = true;
+                connectionString = connectionStringBuilder.ToString();
+            }
 
             if (string.IsNullOrWhiteSpace(connectionStringBuilder.GetProvider()))
             {

--- a/src/EFCore.Jet/Scaffolding/Internal/JetDatabaseModelFactory.cs
+++ b/src/EFCore.Jet/Scaffolding/Internal/JetDatabaseModelFactory.cs
@@ -102,7 +102,6 @@ namespace EntityFrameworkCore.Jet.Scaffolding.Internal
             {
                 connection.Open();
                 _ignoreMsys = ((JetConnection)connection).IgnoreMsys;
-                System.Console.WriteLine(_ignoreMsys);
             }
 
             try


### PR DESCRIPTION
From #216 some databases can not get info on the columns for some `MSys` (system) tables.

Add an option to the connection string to allow users to not do any scaffolding on those system tables

Sample connection string is `"Provider=Microsoft.ACE.OLEDB.12.0;Data Source=northwind.accdb;IgnoreMsys=YES;"`

The presence of the `IgnoreMsys` key will set the option
